### PR TITLE
Delay the timer randomly

### DIFF
--- a/certbot.timer
+++ b/certbot.timer
@@ -4,6 +4,7 @@ Description=weekly check for letsencrypt renewals
 [Timer]
 OnCalendar=weekly
 Persistent=True
- 
+RandomizedDelaySec=1h
+
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
To avoid timer of all deployments fire at the same time, this commit
delays its start date.  We take one hour delay, the timezone of the
deployment will spread it on the whole day.

Renewal will still be done a Monday and not any other day—but it is
less important.